### PR TITLE
feat(codes): attach error codes to the constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,20 @@ A simple Node.js library for easily creating classed Boom errors in Hapi applica
 
 # Usage
 
-### `createBoomError(name, statusCode, [message])`
+### `createBoomError(name, statusCode, [message], [code])`
 
 Creates a Boom error.
 - `name` - The name of the error.
 - `statusCode` - the integer status code of the Boom error
 - `message` - an optional string or function which returns a string
+- `code` - an optional machine-keyable error status string
 
 ### Create a simple error
 
 ```js
 var createBoomError = require('create-boom-error');
 
-var MyError = createBoomError('MyError', 404, 'simple message');
+var MyError = createBoomError('MyError', 404, 'simple message', 'not_found');
 
 var err = new MyError();
 

--- a/index.js
+++ b/index.js
@@ -7,27 +7,31 @@ const Boom = require('@hapi/boom');
  * @param {string} name
  * @param {number} statusCode
  * @param {function | string} message
+ * @param {string} code
  * @returns {new () => Boom<null>}
  */
-function createBoomError(name, statusCode, message) {
+function createBoomError(name, statusCode, message, code) {
   var exports = this;
 
   function ErrorCtor () {
     this.name = name;
+    if (code) {
+      this.code = code;
+    }
 
     this.message = undefined;
     if (typeof message === 'string') {
       this.message = message;
     } else if (typeof message === 'function') {
-      this.message = message.apply(undefined, arguments);
+      this.message = message.apply(null, arguments);
     }
 
-    Boom.boomify(this, { statusCode, });
+    Boom.boomify(this, { statusCode });
 
-    if (message === undefined) {
+    if (!message) {
       Reflect.deleteProperty(this.output.payload, 'message');
     }
-  }
+  };
 
   ErrorCtor.prototype = Object.create(Error.prototype);
   ErrorCtor.prototype.constructor = ErrorCtor;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "test": "test"
   },
   "scripts": {
-    "test": "mocha test test/index.test.js"
+    "test": "mocha test test/index.test.js",
+    "release:major": "changelog -M && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && npm version major && git push origin && git push origin --tags",
+    "release:minor": "changelog -m && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && npm version minor && git push origin && git push origin --tags",
+    "release:patch": "changelog -p && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && npm version patch && git push origin && git push origin --tags"
   },
   "repository": {
     "type": "git",
@@ -26,6 +29,7 @@
   "homepage": "https://github.com/lob/create-boom-error",
   "devDependencies": {
     "chai": "^2.1.2",
+    "generate-changelog": "^1.8.0",
     "mocha": "^7.1.0"
   },
   "dependencies": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,6 +12,7 @@ describe('createBoomError', function () {
     expect(err instanceof StringError).to.be.true;
     expect(err instanceof Error).to.be.true;
     expect(err.message).to.eql('string message');
+    expect(err.code).to.not.exist;
     expect(err.output).to.eql({
       statusCode: 404,
       payload: {
@@ -31,6 +32,7 @@ describe('createBoomError', function () {
     expect(err instanceof FunctionError).to.be.true;
     expect(err instanceof Error).to.be.true;
     expect(err.message).to.eql('value is one');
+    expect(err.code).to.not.exist;
     expect(err.output).to.eql({
       statusCode: 422,
       payload: {
@@ -47,6 +49,24 @@ describe('createBoomError', function () {
     var err = new EmptyError();
     expect(err instanceof EmptyError).to.be.true;
     expect(err instanceof Error).to.be.true;
+    expect(err.code).to.not.exist;
+    expect(err.output).to.eql({
+      statusCode: 422,
+      payload: {
+        statusCode: 422,
+        error: 'Unprocessable Entity'
+      },
+      headers: {}
+    });
+  });
+
+  it('should create a boom error with an optional error code', () => {
+    const code = 'invalid';
+    const CodeError = createBoomError('CodeError', 422, null, code);
+    const err = new CodeError();
+    expect(err instanceof CodeError).to.be.true;
+    expect(err instanceof Error).to.be.true;
+    expect(err.code).to.eql(code);
     expect(err.output).to.eql({
       statusCode: 422,
       payload: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,6 +66,11 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
+bluebird@^3.0.6:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -143,6 +148,11 @@ color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+commander@^2.9.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -257,10 +267,24 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+generate-changelog@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/generate-changelog/-/generate-changelog-1.8.0.tgz#1d788cdef5a13a649da7eb2a1f3b02674850e4a8"
+  integrity sha512-msgpxeB75Ziyg3wGsZuPNl7c5RxChMKmYcAX5obnhUow90dBZW3nLic6nxGtst7Bpx453oS6zAIHcX7F3QVasw==
+  dependencies:
+    bluebird "^3.0.6"
+    commander "^2.9.0"
+    github-url-from-git "^1.4.0"
+
 get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+github-url-from-git@^1.4.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/github-url-from-git/-/github-url-from-git-1.5.0.tgz#f985fedcc0a9aa579dc88d7aff068d55cc6251a0"
+  integrity sha1-+YX+3MCpqledyI16/waNVcxiUaA=
 
 glob-parent@~5.1.0:
   version "5.1.0"


### PR DESCRIPTION
## What
Adds an optional `code` argument to the constructor

## Why
So we can add error codes to the error classes we're creating in lob-api

## Related PRs
lob/hapi-format-error#13

## Next steps
* Cut a new minor version of this pkg
* Update pkg in lob/lob-api passing in new `code` parameter
